### PR TITLE
Remove default value of device name

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -22,7 +22,7 @@ Options:
     -t DATE        Use the specified date string (format: YYYYMMDD)
     -k KEYWORDS    Comma separated keywords that will be added to the PDF metadata.
 
-    -d DEVICE      Set the device [default: brother4:net1;dev0].
+    -d DEVICE      Set the device.
     -r RESOLUTION  Set the resolution [default: 300].
     -c PAGES       Page count to scan [default: all pages from ADF]
 
@@ -182,12 +182,13 @@ class Scan:
                 print(prefix() + 'Scanning page %d/%d...' % (number + 1, self.count))
             scanimage_args = {
                 'x': 210, 'y': 297,
-                'device_name': self.device,
                 'batch': True,
                 'format': 'tiff',
                 'resolution': self.resolution,
                 '_ok_code': [0, 7],
             }
+            if self.device is not None:
+                scanimage_args['device_name'] = self.device
             if number is not None:
                 scanimage_args['batch-start'] = number
                 scanimage_args['batch-count'] = 1


### PR DESCRIPTION
The specified default scanner will probably not work for most users,
so everyone needs to explicitly override this argument.

When removing the default scanner name completely, the `--device-name`
argument for `scanimage` can be omitted. Then `scanimage` tries to find
a suitable device by itself. From `scanimage` manpage:

    If no device-name is specified explicitly, scanimage reads a
    device-name from the environment variable SANE_DEFAULT_DEVICE.
    If this variable is not set, scanimage will attempt to open the
    first available device.